### PR TITLE
Expect file name as input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,5 @@ To use `notion2markdown`, you'll need both your Notion Integration token and the
 ```bash
 mint run notion2markdown \
 --notion-token <your-notion-token> \
---database-id <your-database-id>
-```
-
-Additionally, if you wish to save the markdown to a local file, supply the `--output-directory` option:
-```bash
-mint run notion2markdown \
---notion-token <your-notion-token> \
---database-id <your-database-id> \
---output-directory <your-output-directory> \
+--database-id <your-database-id> \ 
 ```

--- a/Sources/CommandLineTool/CommandLineTool.swift
+++ b/Sources/CommandLineTool/CommandLineTool.swift
@@ -22,8 +22,8 @@ struct CommandLineTool: AsyncParsableCommand {
     @Option(help: "The identifier of your Notion database to read from.")
     var databaseID: String
 
-    @Option(help: "The directory to output the markdown file and associated assets")
-    var outputDirectory: String = "./"
+    @Option(help: "The markdown file output path")
+    var output: String = "output.md"
 
     // MARK: Command
 
@@ -33,8 +33,8 @@ struct CommandLineTool: AsyncParsableCommand {
         // Select a Page
         let page = try await selectPageToPublish(notionClient: client)
 
-        // Convert to markdown and save to the output directory
-        try await client.convertPageToMarkdown(page, outputDirectory: outputDirectory)
+        // Convert and save to a markdown file
+        try await client.convertPageToMarkdown(page, outputPath: output)
     }
 
     // MARK: Private API

--- a/Sources/Notion2MarkdownCore/NotionClient.swift
+++ b/Sources/Notion2MarkdownCore/NotionClient.swift
@@ -43,12 +43,17 @@ public struct Notion2MarkdownClient {
     }
 
     // MARK: Markdown Conversion
-
-    public func convertPageToMarkdown(_ page: Page, outputDirectory: String) async throws {
+        
+    /// - Parameters:
+    ///   - page: The Notion `Page` to convert into a markdown file.
+    ///   - outputPath: The path in which to write the markdown file (e.g. `./foo/bar/output.md`)
+    public func convertPageToMarkdown(
+        _ page: Page,
+        outputPath: String
+    ) async throws {
         guard let pageTitle = page.plainTextTitle else {
             throw Notion2MarkdownError.pageMissingTitle
         }
-
         // Retrieve the blocks from the page.
         let blocks = try await internalClient.allBlockChildren(blockId: page.id.toBlockIdentifier)
 
@@ -59,11 +64,11 @@ public struct Notion2MarkdownClient {
         // Save the markdown file
         let markdown = markdownBlocks.joined(separator: .doubleNewline)
 
-        let outputURL = URL(fileURLWithPath: outputDirectory, isDirectory: true)
-            .appending(path: "\(pageTitle.replacingOccurrences(of: " ", with: "-")).md")
+        let outputURL = URL(fileURLWithPath: outputPath, isDirectory: true)
         try fileManager.write(markdown, to: outputURL, atomically: true, encoding: .utf8)
 
         // Download all referenced images
+        let outputDirectory = (outputPath as NSString).deletingLastPathComponent
         try await withThrowingTaskGroup(of: Void.self) { group in
             for imageURL in blocks.imageURLs {
                 group.addTask {

--- a/Sources/Notion2MarkdownCore/NotionClient.swift
+++ b/Sources/Notion2MarkdownCore/NotionClient.swift
@@ -43,7 +43,7 @@ public struct Notion2MarkdownClient {
     }
 
     // MARK: Markdown Conversion
-        
+
     /// - Parameters:
     ///   - page: The Notion `Page` to convert into a markdown file.
     ///   - outputPath: The path in which to write the markdown file (e.g. `./foo/bar/output.md`)

--- a/Tests/Notion2MarkdownCoreTests/Notion2MarkdownClientTests.swift
+++ b/Tests/Notion2MarkdownCoreTests/Notion2MarkdownClientTests.swift
@@ -74,7 +74,7 @@ final class Notion2MarkdownClientTests: XCTestCase {
         let client = Notion2MarkdownClient(internalClient: mockNotionClient)
 
         do {
-            _ = try await client.convertPageToMarkdown(.mocked(), outputDirectory: "")
+            _ = try await client.convertPageToMarkdown(.mocked(), outputPath: "")
             XCTFail("Expected error thrown due to page missing a title")
         } catch let error as Notion2MarkdownError {
             XCTAssertEqual(error, .pageMissingTitle)
@@ -103,7 +103,7 @@ private extension Notion2MarkdownClientTests {
 
         let writeExpectation = expectation(description: "Markdown was written to file")
         mockFileManager.writeExpectation = writeExpectation
-        try await client.convertPageToMarkdown(.titledPage(MockData.pageTitle), outputDirectory: "")
+        try await client.convertPageToMarkdown(.titledPage(MockData.pageTitle), outputPath: "")
         await fulfillment(of: [writeExpectation])
         let actualMarkdown = try XCTUnwrap(mockFileManager.writeInput)
 


### PR DESCRIPTION
- Renames the `outputDirectory` option to `output`
- Expects the caller to provide a full path to a markdown file (vs just pointing to a destination directory), defaulting to `output.md`