### PR TITLE
Make prefixing the page title as an H1 an optional flag

### DIFF
--- a/Sources/CommandLineTool/CommandLineTool.swift
+++ b/Sources/CommandLineTool/CommandLineTool.swift
@@ -25,6 +25,9 @@ struct CommandLineTool: AsyncParsableCommand {
     @Option(help: "The markdown file output path")
     var output: String = "output.md"
 
+    @Flag(help: "Whether the Notion Page's title should be appended as an H1 element to the final output file")
+    var prefixPageTitle: Bool = false
+
     // MARK: Command
 
     mutating func run() async throws {
@@ -34,7 +37,7 @@ struct CommandLineTool: AsyncParsableCommand {
         let page = try await selectPageToPublish(notionClient: client)
 
         // Convert and save to a markdown file
-        try await client.convertPageToMarkdown(page, outputPath: output)
+        try await client.convertPageToMarkdown(page, outputPath: output, prefixPageTitle: prefixPageTitle)
     }
 
     // MARK: Private API

--- a/Sources/Notion2MarkdownCore/Notion2MarkdownError.swift
+++ b/Sources/Notion2MarkdownCore/Notion2MarkdownError.swift
@@ -9,16 +9,12 @@ public enum Notion2MarkdownError: LocalizedError {
     /// Occurs when providing an invalid index when prompted to select a page to publish
     case invalidPageSelectionIndex
 
-    case pageMissingTitle
-
     public var errorDescription: String? {
         switch self {
         case .invalidPageSelectionInput:
             "Please enter a valid integer index."
         case .invalidPageSelectionIndex:
             "Please choose a valid page index."
-        case .pageMissingTitle:
-            "Unable to find or parse the title for the page"
         }
     }
 }

--- a/Sources/Notion2MarkdownCore/NotionClient.swift
+++ b/Sources/Notion2MarkdownCore/NotionClient.swift
@@ -47,18 +47,20 @@ public struct Notion2MarkdownClient {
     /// - Parameters:
     ///   - page: The Notion `Page` to convert into a markdown file.
     ///   - outputPath: The path in which to write the markdown file (e.g. `./foo/bar/output.md`)
+    ///   - prefixPageTitle: Whether to prefix that page's title as an H1 element to the final markdown.
     public func convertPageToMarkdown(
         _ page: Page,
-        outputPath: String
+        outputPath: String,
+        prefixPageTitle: Bool = false
     ) async throws {
-        guard let pageTitle = page.plainTextTitle else {
-            throw Notion2MarkdownError.pageMissingTitle
-        }
         // Retrieve the blocks from the page.
         let blocks = try await internalClient.allBlockChildren(blockId: page.id.toBlockIdentifier)
 
         // Add the title as a heading in the final markdown
-        var markdownBlocks: [String] = [pageTitle.convertedToMarkdown(.heading1)]
+        var markdownBlocks: [String] = []
+        if prefixPageTitle, let pageTitle = page.plainTextTitle {
+            markdownBlocks.append(pageTitle.convertedToMarkdown(.heading1))
+        }
         markdownBlocks.append(contentsOf: blocks.compactMap { $0.type.asMarkdown })
 
         // Save the markdown file

--- a/Tests/Notion2MarkdownCoreTests/MockData/MockData.swift
+++ b/Tests/Notion2MarkdownCoreTests/MockData/MockData.swift
@@ -17,8 +17,6 @@ enum MockData {
     ]
 
     static let numberedListMarkdown: String = """
-    # \(pageTitle)
-
     1. Item 1
 
     1. Item 2
@@ -41,8 +39,6 @@ enum MockData {
     ]
 
     static let bulletedListItemMarkdown: String = """
-    # \(pageTitle)
-
     - Plaintext list item
 
     - **Bold list item**
@@ -65,8 +61,6 @@ enum MockData {
     ]
 
     static let calloutMarkdown: String = """
-    # \(pageTitle)
-
     > Plaintext callout
 
     > **Bold callout**
@@ -86,8 +80,6 @@ enum MockData {
     ]
 
     static let codeMarkdown: String = """
-    # \(pageTitle)
-
     ```Swift
     let foo = "bar"
     ```
@@ -105,8 +97,6 @@ enum MockData {
     ]
 
     static let embedMarkdown: String = """
-    # \(pageTitle)
-
     [](nocaption.com)
 
     [This is a link caption](caption.com)
@@ -121,8 +111,6 @@ enum MockData {
     ]
 
     static let headingMarkdown: String = """
-    # \(pageTitle)
-
     # Heading 1
 
     ## Heading 2
@@ -141,8 +129,6 @@ enum MockData {
     ]
 
     static let quoteMarkdown: String = """
-    # \(pageTitle)
-
     > Plaintext quote
 
     > **Bold quote**
@@ -162,8 +148,6 @@ enum MockData {
     ]
 
     static let todoMarkdown: String = """
-    # \(pageTitle)
-
     - [x] Checked
 
     - [ ] Unchecked
@@ -179,8 +163,6 @@ enum MockData {
     ]
 
     static let imageMarkdown: String = """
-    # \(pageTitle)
-
     ![Private Image](image1.png)
 
     ![](image2.png)


### PR DESCRIPTION
Now allows the caller to control whether the Notion Page's title gets prefixed as an H1 element to the top of the final markdown file.